### PR TITLE
Generalize cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(Boost_NO_BOOST_CMAKE ON)
 find_package(Boost)
 include_directories(${Boost_INCLUDE_DIR})
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -DUSE_VECGEOM_NAVIGATOR -I/Users/lima/work/geantv/include")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -DUSE_VECGEOM_NAVIGATOR -I${GeantV_INCLUDE_DIR}/include")
 
 add_subdirectory(BusyWaitCalibration)
 add_subdirectory(SingleThreadedProcessingDemo)

--- a/TBBProcessingDemo/CMakeLists.txt
+++ b/TBBProcessingDemo/CMakeLists.txt
@@ -57,7 +57,7 @@ include_directories(${GeantV_INCLUDE_DIR}/xsec/inc)
 include_directories(${GeantV_INCLUDE_DIR}/vecprot_v2/inc)
 include_directories(${GeantV_INCLUDE_DIR}/vecprot_v2_tbb/inc)
 include_directories(${GeantV_INCLUDE_DIR}/examples/inc)
-set(GEANTV_LIBRARIES ${GEANTV_LIBRARIES} ${GeantV_DIR}/lib/libGeant_v.so ${GeantV_DIR}/lib/libGeant_tbb.so ${GeantV_DIR}/lib/libGeantExamples.so ${GeantV_DIR}/lib/libXsec.so)
+set(GEANTV_LIBRARIES ${GEANTV_LIBRARIES} ${GeantV_DIR}/lib/libGeant_v.so ${GeantV_DIR}/lib/libGeantExamples.so ${GeantV_DIR}/lib/libXsec.so)
 
 include_directories(${VecGeom_INCLUDE_DIR})
 

--- a/TBBProcessingDemo/CMakeLists.txt
+++ b/TBBProcessingDemo/CMakeLists.txt
@@ -52,14 +52,14 @@ if(HepMC_FOUND)
   set(VECGEOM_LIBRARIES ${VECGEOM_LIBRARIES} ${HEPMC_LIBRARIES})
 endif()
 
-include_directories("/Users/lima/work/geantv/base/inc")
-include_directories("/Users/lima/work/geantv/xsec/inc")
-include_directories("/Users/lima/work/geantv/vecprot_v2/inc")
-include_directories("/Users/lima/work/geantv/vecprot_v2_tbb/inc")
-include_directories("/Users/lima/work/geantv/examples/inc")
+include_directories(${GeantV_INCLUDE_DIR}/base/inc)
+include_directories(${GeantV_INCLUDE_DIR}/xsec/inc)
+include_directories(${GeantV_INCLUDE_DIR}/vecprot_v2/inc)
+include_directories(${GeantV_INCLUDE_DIR}/vecprot_v2_tbb/inc)
+include_directories(${GeantV_INCLUDE_DIR}/examples/inc)
 set(GEANTV_LIBRARIES ${GEANTV_LIBRARIES} ${GeantV_DIR}/lib/libGeant_v.so ${GeantV_DIR}/lib/libGeant_tbb.so ${GeantV_DIR}/lib/libGeantExamples.so ${GeantV_DIR}/lib/libXsec.so)
 
-include_directories("/opt/local/vecgeom/install/include")
+include_directories(${VecGeom_INCLUDE_DIR})
 
 set(CORE_FILES
     TBBFrameworkCore/Event.cpp


### PR DESCRIPTION
In my cmake command I include these definitions (following the directory setup in https://github.com/kpedro88/install-geant):
```
-DVecGeom_DIR=$LOCAL/vecgeom/install/lib/CMake/VecGeom/ -DVecGeom_INCLUDE_DIR=$LOCAL/vecgeom/install/include -DGeantV_DIR=$LOCAL/geantv/install -DGeantV_INCLUDE_DIR=$LOCAL/../geant
```

For the `GeantV_INCLUDE_DIR`, one needs the whole source directory.