### PR TITLE
make file locations configurable

### DIFF
--- a/TBBProcessingDemo/TBBTestModules/GeantVProducer.cpp
+++ b/TBBProcessingDemo/TBBTestModules/GeantVProducer.cpp
@@ -39,7 +39,7 @@ namespace {
     tbb::task* execute() override {
       printf("SimTask: iWaiting=%p\n", m_waitingTask);
 
-      //IMPORTANT: decremeting the reference count is what
+      //IMPORTANT: decrementing the reference count is what
       // tells the framework the simulation is done with
       // this event.
       m_waitingTask->decrement_ref_count();
@@ -102,16 +102,16 @@ namespace demo {
     bool monitor = false, score = false, debug = false, coprocessor = false, tbbmode = false, usev3 = true, usenuma = false;
     bool performance = true;
 
-    //std::string cms_geometry_filename("cms2015.root");
-    std::string cms_geometry_filename("cms2018.gdml");
-    //std::string cms_geometry_filename("ExN03.root");
+    //e.g. cms2015.root, cms2018.gdml, ExN03.root
+    std::string cms_geometry_filename = iConfig.get<std::string>("geometry");
 
-    std::string xsec_filename("xsec_FTFP_BERT.root");
-    std::string fstate_filename("fstate_FTFP_BERT.root");
+    std::string xsec_filename = iConfig.get<std::string>("xsec");
+    std::string fstate_filename = iConfig.get<std::string>("fstate");
 
-    //std::string hepmc_event_filename("pp14TeVminbias.root");  // sequence #stable: 608 962 569 499 476 497 429 486 465 619
-    std::string hepmc_event_filename("minbias_14TeV.root"); // sequence #stable: 81 84 93 97 87 60 106 91 92 60
-    //std::string hepmc_event_filename(""); // use gun generator!
+    std::string hepmc_event_filename = iConfig.get<std::string>("hepmc");
+    // pp14TeVminbias.root sequence #stable: 608 962 569 499 476 497 429 486 465 619
+    // minbias_14TeV.root sequence #stable: 81 84 93 97 87 60 106 91 92 60
+    // if empty, use gun generator!
 
     // instantiate configuration helper
     fConfig = new GeantConfig();

--- a/geantv_inputFromFile.json
+++ b/geantv_inputFromFile.json
@@ -30,7 +30,10 @@
      { "@label" : "geantV",
        "@type" : "demo::GeantVProducer",
        "threadType" : "ThreadSafeBetweenInstances",
-       "fileName" : "pp14TeVminbias.root",
+       "geometry" : "cms2018.gdml",
+       "xsec" : "xsec_FTFP_BERT.root",
+       "fstate" : "fstate_FTFP_BERT.root",
+       "hepmc" : "minbias_14TeV.root",
        "Nevents":9999,
        "Nthreads":8,
        "toGet" :[]


### PR DESCRIPTION
This PR simplifies the setup for running GeantVProducer:
1. No need to symlink files, just keep a copy of the config file with absolute paths for one's local system
2. xsec and fstate files can be accessed over xrootd (large files can be kept on mass storage)

(Unfortunately HepMC3 can't read input files over xrootd - I opened an issue https://gitlab.cern.ch/hepmc/HepMC3/issues/1 for this.)

@mrguilima, questions for you:
1. I only updated the config file `geantv_inputFromFile.json` since that's the one I've been testing. Should I update the others? Are they all still needed?
2. Is there some way to suppress printing reams of geometry, etc. information? This seems wholly unnecessary.